### PR TITLE
Migrating from 2.0 to 2.4

### DIFF
--- a/Lib/Network/Http/WebSocket.php
+++ b/Lib/Network/Http/WebSocket.php
@@ -80,7 +80,7 @@ class WebSocket extends HttpSocket {
 		if($this->_handshake->code != 200) {
 			$this->disconnect();
 			if(!empty($this->config['silent'])) return false;
-			throw new ServiceUnavailableException();
+			throw new ServiceUnavailableException('Service unavailable', 503);
 		}
 		// dd($this->_handshake->code);
 
@@ -105,7 +105,7 @@ class WebSocket extends HttpSocket {
 		} catch(Exception $e) {
 			$this->disconnect();
 			if(!empty($this->config['silent'])) return false;
-			throw new ServiceUnavailableException();
+			throw new ServiceUnavailableException('Service unavailable', 503);
 		}
 
 		$receivedKey = $this->_transport->headers['Sec-WebSocket-Accept'];
@@ -114,7 +114,7 @@ class WebSocket extends HttpSocket {
 		if($receivedKey != $expectedKey) {
 			$this->disconnect();
 			if(!empty($this->config['silent'])) return false;
-			throw new ServiceUnavailableException();
+			throw new ServiceUnavailableException('Service unavailable', 503);
 		}
 
 		$connect = $this->read(5);

--- a/readme.md
+++ b/readme.md
@@ -4,7 +4,7 @@ by `Olivier Louvignes`
 
 ### Description
 
-This repository contains a [CakePHP 2.0](https://github.com/cakephp) plugin that provides:
+This repository contains a [CakePHP 2.0]+(https://github.com/cakephp) plugin that provides:
 
 * `WebSocket Object` (that extends HttpSocket core class) to act as websocket client
 
@@ -22,7 +22,7 @@ This repository contains a [CakePHP 2.0](https://github.com/cakephp) plugin that
 
 3. To configure one of your model to use the `Publishable` Behavior.
 
-		public $actsAs = array('Publishable' => array('fields' => array('name', 'status_date', 'status_code', 'status_progress')),
+		public $actsAs = array('WebSocket.Publishable' => array('fields' => array('name', 'status_date', 'status_code', 'status_progress')),
 
 4. To configure one of your controller to use a socket.
 
@@ -40,11 +40,23 @@ This repository contains a [CakePHP 2.0](https://github.com/cakephp) plugin that
 		  });
 		});
 
+6. Implement this custom Exception
+		// in bootstrap.php
+		require(APP . 'Lib' . DS . 'MyExceptions.php');
+
+
+		// in /Lib/MyExceptions.php
+		class ServiceUnavailableException extends CakeException {
+
+		    protected $_messageTemplate = 'Test';
+		}
+
+
 ### Interface
 
 Quick example:
 
-	$websocket = new WebSocket(array('port' => 8080));
+	$websocket = new WebSocket(array('port' => 8080, 'scheme'=>'ws'));
 
 	if($websocket->connect()) {
 

--- a/readme.md
+++ b/readme.md
@@ -41,6 +41,7 @@ This repository contains a [CakePHP 2.0]+(https://github.com/cakephp) plugin tha
 		});
 
 6. Implement this custom Exception
+
 		// in bootstrap.php
 		require(APP . 'Lib' . DS . 'MyExceptions.php');
 


### PR DESCRIPTION
All minor changes:

"$Model" argument in HttpSocket is now "Model $model", according to the cake standard. This was breaking in Cake 2.4.

ServiceUnavailableException doesn't exist, so it has to be defined. Added instructions to readme

$actsAs must now specify name of the Plugin as the prefix. Modified readme instructions

Once I made these changes everything worked flawlessly. Thanks for releasing this!
